### PR TITLE
fix: merge yaml values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telefonica/language-model-converter",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Language model converter yaml <-> json for LUIS",
   "license": "Apache-2.0",
   "repository": "https://github.com/Telefonica/yot-bot/tree/master/language-model-converter",

--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 
 import { LanguageModelParser } from './parser';
+import { Luis } from './luis-model';
 
 describe('Language Model Converter', () => {
     it('should parse a valid yaml file', () => {
@@ -399,4 +400,60 @@ describe('Language Model Converter', () => {
         expect(luisModel.bing_entities).to.eql(expectedBingEntities);
 
     });
+
+    it('should merge keys', function() {
+        let parser = new LanguageModelParser();
+        let yamls = [
+            './test/fixtures/en-merge-1.yaml',
+            './test/fixtures/en-merge-2.yaml'
+        ];
+        let luisModel = parser.parse(yamls, 'en-us');
+
+        let expectedModelFeatures = [
+            {
+                name: 'colors',
+                words: 'red,blue,white,yellow,green,black',
+                activated: true,
+                mode: true
+            }
+        ];
+
+        expect(luisModel.model_features).to.eql(expectedModelFeatures);
+    });
+
+    it('should merge values', function() {
+        let parser = new LanguageModelParser();
+        let yamls = [
+            './test/fixtures/en-merge-1.yaml',
+            './test/fixtures/en-merge-2.yaml',
+            './test/fixtures/en-merge-3.yaml'
+        ];
+        let luisModel = parser.parse(yamls, 'en-us');
+
+        let expectedUtterances = [
+            {
+                text: 'this is a test utterance 1',
+                intent: 'my.test.intent',
+                entities: [] as Luis.EntityPosition[]
+            },
+            {
+                text: 'this is a test utterance 2',
+                intent: 'my.test.intent',
+                entities: [] as Luis.EntityPosition[]
+            },
+            {
+                text: 'this is a test utterance 3',
+                intent: 'my.test.intent',
+                entities: [] as Luis.EntityPosition[]
+            },
+            {
+                text: 'this is a test utterance 4',
+                intent: 'my.test.intent',
+                entities: [] as Luis.EntityPosition[]
+            }
+        ];
+
+        expect(luisModel.utterances).to.eql(expectedUtterances);
+    });
+
 });

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -295,14 +295,28 @@ function isObject(item: any) {
 function mergeDeep(target: any, source: any) {
     if (isObject(target) && isObject(source)) {
         for (const key in source) {
-        if (isObject(source[key])) {
-            if (!target[key]) {
-                Object.assign(target, { [key]: {} });
+            if (!source[key]) {
+                // Ignore empty values such as an intent key without examples
+                continue;
+            } else if (isObject(source[key])) {
+                if (!target[key]) {
+                    Object.assign(target, { [key]: {} });
+                }
+                if (!isObject(target[key])) {
+                    throw new Error(`Property ${key} already exist in target but it is not an object`);
+                }
+                mergeDeep(target[key], source[key]);
+            } else if (Array.isArray(source[key])) {
+                if (!target[key]) {
+                    Object.assign(target, { [key]: [] });
+                }
+                if (!Array.isArray(target[key])) {
+                    throw new Error(`Property ${key} already exist in target but it is not an array`);
+                }
+                target[key] = _.uniq(target[key].concat(source[key]));
+            } else {
+                Object.assign(target, { [key]: source[key] });
             }
-            mergeDeep(target[key], source[key]);
-        } else {
-            Object.assign(target, { [key]: source[key] });
-        }
         }
     }
     return target;

--- a/test/fixtures/en-merge-1.yaml
+++ b/test/fixtures/en-merge-1.yaml
@@ -1,0 +1,10 @@
+phraselist:
+  colors:
+    words:
+      - red
+      - blue
+      - white
+
+my.test.intent:
+  - This is a test utterance 1
+  - This is a test utterance 2

--- a/test/fixtures/en-merge-2.yaml
+++ b/test/fixtures/en-merge-2.yaml
@@ -1,0 +1,10 @@
+phraselist:
+  colors:
+    words:
+      - yellow
+      - green
+      - black
+
+my.test.intent:
+  - This is a test utterance 3
+  - This is a test utterance 4

--- a/test/fixtures/en-merge-3.yaml
+++ b/test/fixtures/en-merge-3.yaml
@@ -1,0 +1,7 @@
+phraselist:
+  colors:
+    words:
+    # Empty
+
+my.test.intent:
+# Empty


### PR DESCRIPTION
Improve the `mergeDeep` algorithm to concat arrays (yaml values are parsed as arrays). It also removes repeated elements from arrays.

Fixes #8 
